### PR TITLE
Ethereum Block path parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "js-ipld-eth-block",
+  "version": "1.0.0",
+  "description": "JavaScript Implementation of the IPLD format - Ethereum Block",
+  "main": "src/index.js",
+  "directories": {
+    "test": "test"
+  },
+  "dependencies": {
+    "ethereumjs-block": "^1.3.1"
+  },
+  "devDependencies": {
+    "aegir": "^8.1.2",
+    "chai": "^3.5.0"
+  },
+  "scripts": {
+    "test": "aegir-test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ipld/js-ipld-eth-block.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ipld/js-ipld-eth-block/issues"
+  },
+  "homepage": "https://github.com/ipld/js-ipld-eth-block#readme"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,4 @@
+'use strict'
+
+exports.util = require('./util.js')
+exports.resolver = require('./resolver.js')

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const EthBlockHeader = require('ethereumjs-block/header')
+
+exports.deserialize = function(data) {
+  return new EthBlockHeader(data)
+}
+
+exports.serialize = function(blockHeader) {
+  return blockHeader.serialize()
+}

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -1,0 +1,60 @@
+/* eslint-env mocha */
+'use strict'
+
+const expect = require('chai').expect
+const dagEthBlock = require('../src')
+const resolver = dagEthBlock.resolver
+const IpfsBlock = require('ipfs-block')
+const EthBlockHeader = require('ethereumjs-block/header')
+const ethUtils = require('ethereumjs-util')
+
+describe('IPLD format resolver (local)', () => {
+  let testIpfsBlock
+  let testData = {
+    //                            12345678901234567890123456789012
+    parentHash:       new Buffer('0100000000000000000000000000000000000000000000000000000000000000', 'hex'),
+    uncleHash:        new Buffer('0200000000000000000000000000000000000000000000000000000000000000', 'hex'),
+    coinbase:         new Buffer('0300000000000000000000000000000000000000', 'hex'),
+    stateRoot:        new Buffer('0400000000000000000000000000000000000000000000000000000000000000', 'hex'),
+    transactionsTrie: new Buffer('0500000000000000000000000000000000000000000000000000000000000000', 'hex'),
+    receiptTrie:      new Buffer('0600000000000000000000000000000000000000000000000000000000000000', 'hex'),
+    // bloom:            new Buffer('07000000000000000000000000000000', 'hex'),
+    difficulty:       new Buffer('0800000000000000000000000000000000000000000000000000000000000000', 'hex'),
+    number:           new Buffer('0900000000000000000000000000000000000000000000000000000000000000', 'hex'),
+    gasLimit:         new Buffer('1000000000000000000000000000000000000000000000000000000000000000', 'hex'),
+    gasUsed:          new Buffer('1100000000000000000000000000000000000000000000000000000000000000', 'hex'),
+    timestamp:        new Buffer('1200000000000000000000000000000000000000000000000000000000000000', 'hex'),
+    extraData:        new Buffer('1300000000000000000000000000000000000000000000000000000000000000', 'hex'),
+    mixHash:          new Buffer('1400000000000000000000000000000000000000000000000000000000000000', 'hex'),
+    nonce:            new Buffer('1500000000000000000000000000000000000000000000000000000000000000', 'hex'),
+  }
+
+  before(() => {
+    const testEthBlock = new EthBlockHeader(testData)
+    testIpfsBlock = new IpfsBlock(dagEthBlock.util.serialize(testEthBlock))
+  })
+
+  it('multicodec is eth-block', () => {
+    expect(resolver.multicodec).to.equal('eth-block')
+  })
+
+  describe('eth-block paths', () => {
+    
+    describe('resolver.resolve', () => {
+      
+      it('path within scope', () => {
+        const result = resolver.resolve(testIpfsBlock, 'number')
+        expect(result.value.toString('hex')).to.equal(testData.number.toString('hex'))
+      })
+
+      describe.skip('path outside scope')
+
+    })
+
+    it('resolver.tree', () => {
+      const paths = resolver.tree(testIpfsBlock)
+      expect(Array.isArray(paths)).to.eql(true)
+    })
+
+  })
+})

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -6,7 +6,6 @@ const dagEthBlock = require('../src')
 const resolver = dagEthBlock.resolver
 const IpfsBlock = require('ipfs-block')
 const EthBlockHeader = require('ethereumjs-block/header')
-const ethUtils = require('ethereumjs-util')
 
 describe('IPLD format resolver (local)', () => {
   let testIpfsBlock


### PR DESCRIPTION
This was an interesting exercise and raised some questions.
- how should `resolve` return external links?
- can `resolve` return buffers?
- should `tree` return the values or just the path names?
- since `tree` also returns paths to local data, do we need an api for getting all external links? ( i think yes )
- what is `js-ipld-dag-cbor/src/dag-node`?
- how should we error on path-not-found?
- please add me as a contributor to https://github.com/ipld/js-ipld-eth-block
